### PR TITLE
Fix server port configuration for deployment

### DIFF
--- a/Backend/delivery/main.go
+++ b/Backend/delivery/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/tsigemariamzewdu/JobMate-backend/delivery/controllers"
@@ -138,13 +137,7 @@ func main() {
 	router.Use(middlewares.SetupCORS())
 	router.Use(middlewares.SecurityHeaders())
 
-	port := cfg.AppPort
-	if port == "" {
-		port = os.Getenv("PORT")
-		if port == "" {
-			port = "8080"
-		}
-	}
+	port := config.GetServerPort()
 
 	log.Printf("Server starting on port %s...", port)
 	if err := router.Run(":" + port); err != nil {

--- a/Backend/infrastructure/config/server.go
+++ b/Backend/infrastructure/config/server.go
@@ -8,7 +8,7 @@ import (
 // GetServerPort decides which port to use depending on environment
 func GetServerPort() string {
 	appEnv := os.Getenv("APP_ENV")
-	port := "8080"
+	port := os.Getenv("PORT")
 
 	if appEnv == "development" {
 		// fallback to 8080 in dev if no PORT is set


### PR DESCRIPTION
**Description:**
* Updated `main.go` and `server.go` to ensure the app binds to a valid port in all environments.
* Resolves Render deployment "Port scan timeout" issue.
