### PR TITLE
Update the oauth controller for access token to be returned 

### DIFF
--- a/Backend/delivery/controllers/oauth2_controller.go
+++ b/Backend/delivery/controllers/oauth2_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"net/http"
-	"fmt"
 
 	
 	svc "github.com/tsigemariamzewdu/JobMate-backend/domain/interfaces/services"
@@ -49,7 +48,6 @@ func (ctrl *OAuth2Controller) HandleCallback(c *gin.Context) {
 	// authenticate with the provider
 	oauthUser, err := ctrl.OAuthService.Authenticate(ctx, provider, code)
 	if err != nil {
-		fmt.Print(provider)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return
 	}
@@ -61,10 +59,10 @@ func (ctrl *OAuth2Controller) HandleCallback(c *gin.Context) {
 		return
 	}
 
-	// set auth token cookie
+	// store refresh token in HttpOnly cookie
 	http.SetCookie(c.Writer, &http.Cookie{
-		Name:     "auth_token",
-		Value:    result.AccessToken,
+		Name:     "refresh_token",
+		Value:    result.RefreshToken,
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
@@ -72,7 +70,7 @@ func (ctrl *OAuth2Controller) HandleCallback(c *gin.Context) {
 		MaxAge:   int(result.ExpiresIn.Seconds()),
 	})
 
-	// return safe user response
+	// return access token + safe user response
 	safeUser := gin.H{
 		"user_id":   result.User.UserID,
 		"email":     result.User.Email,
@@ -82,7 +80,9 @@ func (ctrl *OAuth2Controller) HandleCallback(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"message": "OAuth login successful",
-		"user":    safeUser,
+		"message":      "OAuth login successful",
+		"access_token": result.AccessToken,            // return in response
+		"expires_in":   result.ExpiresIn.Seconds(),
+		"user":         safeUser,
 	})
 }


### PR DESCRIPTION
### PR: OAuth login token handling update

**Changes**
* Store **refresh token** in secure, HttpOnly cookie
* Return **access token** in JSON response with expiry info
* Provide clear separation of access vs refresh token usage

**Why**
* Access token must be available to frontend for API requests
* Refresh token should stay secure and inaccessible to JS for safety

