### PR TITLE
Fixed Groq function calling by updating tool parameter format

### DIFF
--- a/Backend/delivery/dto/groq_dto.go
+++ b/Backend/delivery/dto/groq_dto.go
@@ -12,7 +12,7 @@ type GroqToolDTO struct {
 type GroqToolFunctionDTO struct {
 	Name        string                         `json:"name"`
 	Description string                         `json:"description"`
-	Parameters  GroqToolFunctionParametersDTO `json:"parameters"`
+	Parameters  interface{} `json:"parameters"`
 }
 
 

--- a/Backend/infrastructure/ai/groq_client.go
+++ b/Backend/infrastructure/ai/groq_client.go
@@ -53,7 +53,7 @@ func NewGroqClient(cfg *config.Config) *GroqClient {
 }
 
 // GetChatCompletion sends a request to the Groq API and returns the AI's response
-func (gc *GroqClient) GetChatCompletion(ctx context.Context, messages []dto.GroqAIMessageDTO, tools []dto.GroqToolDTO) (*models.GroqAIMessage, error) {
+func (gc *GroqClient) GetChatCompletion(ctx context.Context, messages []dto.GroqAIMessageDTO, tools interface{}) (*models.GroqAIMessage, error) {
 
 	requestBody := struct {
 		Messages    []dto.GroqAIMessageDTO `json:"messages"`
@@ -61,7 +61,7 @@ func (gc *GroqClient) GetChatCompletion(ctx context.Context, messages []dto.Groq
 		Temperature float32                `json:"temperature"`
 		MaxTokens   int                    `json:"max_tokens,omitempty"`
 		Stream      bool                   `json:"stream,omitempty"`
-		Tools       []dto.GroqToolDTO      `json:"tools,omitempty"`
+		Tools       interface{}            `json:"tools,omitempty"`  // Changed to interface{}
 	}{
 		Messages:    messages,
 		Model:       gc.Model,

--- a/Backend/infrastructure/ai_service/job_ai_service.go
+++ b/Backend/infrastructure/ai_service/job_ai_service.go
@@ -130,34 +130,36 @@ func (s *JobAIService) getJobSearchTools() []dto.GroqToolDTO {
             Function: dto.GroqToolFunctionDTO{
                 Name:        "search_jobs",
                 Description: "Search for jobs based on criteria",
-                Parameters: dto.GroqToolFunctionParametersDTO{
-                    Type: "object",
-                    Properties: map[string]dto.GroqToolPropertyDTO{
-                        "field": {
-                            Type:        "string",
-                            Description: "Job field/industry",
+                Parameters: map[string]interface{}{
+                    "type": "object",
+                    "properties": map[string]interface{}{
+                        "field": map[string]interface{}{
+                            "type":        "string",
+                            "description": "Job field/industry",
                         },
-                        "looking_for": {
-                            Type:        "string",
-                            Description: "local, remote, or freelance",
+                        "looking_for": map[string]interface{}{
+                            "type":        "string",
+                            "description": "local, remote, or freelance",
+                            "enum":        []string{"local", "remote", "freelance"},
                         },
-                        "skills": {
-                            Type:        "array",
-                            Description: "Required skills",
-                            Items: &dto.GroqToolPropertyDTO{
-                                Type: "string",
+                        "skills": map[string]interface{}{
+                            "type":        "array",
+                            "description": "Required skills",
+                            "items": map[string]interface{}{
+                                "type": "string",
                             },
                         },
-                        "experience": {
-                            Type:        "string",
-                            Description: "Experience level",
+                        "experience": map[string]interface{}{
+                            "type":        "string",
+                            "description": "Experience level",
                         },
-                        "language": {
-                            Type:        "string",
-                            Description: "en or am",
+                        "language": map[string]interface{}{
+                            "type":        "string",
+                            "description": "en or am",
+                            "enum":        []string{"en", "am"},
                         },
                     },
-                    Required: []string{"field", "looking_for"},
+                    "required": []string{"field", "looking_for"},
                 },
             },
         },


### PR DESCRIPTION
- Changed GroqToolFunctionDTO.Parameters to interface{} for proper JSON Schema
- Updated GroqClient to accept interface{} tools for flexibility
- Fixed job search tool definition with correct JSON Schema format
- Resolved Failed to call a function API errors